### PR TITLE
Modernize styling and fix county map title

### DIFF
--- a/counties.html
+++ b/counties.html
@@ -3,14 +3,18 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Florida Counties Pronunciation Map</title>
+    <title>Pronounce Florida County Map</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <style>
         body {
             margin: 0;
-            font-family: Arial, sans-serif;
+            font-family: 'Roboto', sans-serif;
             display: flex;
             flex-direction: column;
             height: 100vh;
+            background: #f5f7fa;
         }
         #map-container {
             flex: 1;
@@ -58,10 +62,10 @@
                 border-left: 1px solid #ccc;
                 box-shadow: 0 0 10px rgba(0,0,0,0.1);
                 border-radius: 0 0 0 8px;
-                transform: translateY(0);
+                transform: translateX(0);
             }
             #info.collapsed {
-                transform: none;
+                transform: translateX(calc(100% - 40px));
             }
         }
         #play-btn {
@@ -91,11 +95,13 @@
         h1 {
             text-align: center;
             margin: 10px 0;
+            font-size: 1.5em;
+            font-weight: 700;
         }
     </style>
 </head>
 <body>
-    <h1>Proncue Florida County Maps</h1>
+    <h1>Pronounce Florida County Map</h1>
     <div id="map-container">
         <svg></svg>
     </div>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pronounce Florida - An Exploration of Place Names in Florida</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <style>
         body {
-            font-family: Arial, sans-serif;
+            font-family: 'Roboto', sans-serif;
             display: flex;
             justify-content: center;
             align-items: center;
             height: 100vh;
             margin: 0;
-            background-color: #f0f0f0;
+            background: linear-gradient(135deg, #eef2f7, #ffffff);
             text-align: center;
             flex-direction: column;
         }
@@ -20,20 +23,24 @@
             padding: 20px;
             background-color: #fff;
             border-radius: 8px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            max-width: 800px;
+            margin: auto;
         }
         h1 {
             color: #333;
+            font-size: 2em;
+            margin-bottom: 0.5em;
         }
         p {
-            color: #666;
-            font-size: 1.2em;
-            margin-bottom: 10px; /* Added for consistent spacing */
+            color: #555;
+            font-size: 1.1em;
+            margin-bottom: 1em;
         }
-        .project-details { /* New class for detailed paragraphs */
-            font-size: 1.1em; /* Slightly smaller font */
-            color: #333;       /* Darker color for better readability */
-            line-height: 1.6;   /* Improved line spacing */
+        .project-details {
+            font-size: 1.1em;
+            color: #333;
+            line-height: 1.6;
         }
         .description {
             font-size: 1em;

--- a/record.html
+++ b/record.html
@@ -4,16 +4,20 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pronounce Florida - Record Pronunciation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1jft6Jb5PzsUfL5tGI63ZMK+3UU5s5HtmDlfP0jE=" crossorigin="">
     <style>
         body {
             margin: 0;
-            font-family: Arial, sans-serif;
+            font-family: 'Roboto', sans-serif;
             padding: 1em;
-            background-color: #f4f4f4;
+            background: #f5f7fa;
         }
         h1 {
             text-align: center;
+            margin-bottom: 0.5em;
         }
         #map {
             width: 100%;
@@ -31,6 +35,11 @@
         input, select, button, textarea {
             padding: 0.5em;
             font-size: 1em;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+        }
+        .record-controls {
+            margin-top: 0.5em;
         }
         .record-controls button {
             margin-right: 0.5em;


### PR DESCRIPTION
## Summary
- correct misspelled title on county map
- collapse county info panel and apply Roboto font
- modernize index page styling
- modernize record page styling

## Testing
- `tidy -q -e counties.html`
- `tidy -q -e index.html`
- `tidy -q -e record.html`

------
https://chatgpt.com/codex/tasks/task_e_684b3a2e18808327a10f808c3c28cabf