### PR TITLE
Improve homepage with research team list and demo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,17 +47,38 @@
             color: #777;
             margin-top: 10px;
         }
+        h2 {
+            color: #0021A5;
+            font-size: 1.5em;
+            margin-top: 1.5em;
+        }
+        ul.researchers {
+            list-style: none;
+            padding: 0;
+        }
+        ul.researchers li {
+            margin-bottom: 0.5em;
+            font-size: 1.1em;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <h1>Pronounce Florida</h1>
+        <h2>Project Overview</h2>
         <p class="project-details">An exploration of place names in Florida, their origins, and Pronunciation. The result will be an Interactive Web Map and Analysis of Place Names.</p>
         <p class="project-details">The web map will use Leaflet, JavaScript, HTML, CSS, and Bootstrap.</p>
         <p class="project-details">The analysis will include origins of place names, categories of namesakes, and alternative forms that will highlight and enhance the understanding of Florida Geography.</p>
         <p class="project-details">This research project investigates the pronunciation, origin, and cultural significance of place names across Florida. Many Florida place names are derived from Indigenous, Spanish, Anglo, or other linguistic roots and are frequently mispronounced. Our goal is to explore these names and present them in a fun and educational way.</p>
         <p class="project-details">Gemma and Emily will gather historical, cultural, and linguistic information on select place names across cities, towns, lakes, and rivers. They will record or collect audio clips of native and local pronunciations, write attribute tables of each place, and develop an interactive web map to display this information. The final product will be a publicly accessible platform featuring written entries, media elements, and web-based geospatial visualization.</p>
-        <p class="project-details">The project is with <a href="https://sounny.github.io">Dr. Moulay Anwar Sounny-Slitine</a> and with two Reserachers, Gemma Egan and Emily Mancha</p>
+        <h2>Research Team</h2>
+        <ul class="researchers">
+            <li><a href="https://sounny.github.io">Dr. Moulay Anwar Sounny-Slitine</a></li>
+            <li>Gemma Egan</li>
+            <li>Emily Mancha</li>
+        </ul>
+        <h2>Demo</h2>
+        <p class="project-details"><a href="https://sounny.github.io/pronounceglorida/counties.html">View the County Map Demo</a></p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance CSS for headings and researcher list
- add project overview, research team, and demo sections on the homepage
- link Anwar's name to `sounny.github.io` and point demo to `sounny.github.io/pronounceglorida/counties.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9efc163c832791f2786e04ef0cb3