### PR TITLE
Add TTS playback buttons

### DIFF
--- a/counties.html
+++ b/counties.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="leaflet.css">
+    <script src="https://code.responsivevoice.org/responsivevoice.js?key=YOUR_KEY"></script>
     <style>
         body {
             margin: 0;
@@ -76,6 +77,9 @@
             font-size: 10px;
             color: #333;
         }
+        .tts-group{margin-top:4px; display:flex; align-items:center; gap:6px; flex-wrap:wrap;}
+        .tts-group button{padding:2px 6px; cursor:pointer;}
+        .tag{font-size:0.8em; color:#555; margin-right:8px;}
     </style>
 </head>
 <body>
@@ -205,8 +209,64 @@
         const toggleBtn = document.getElementById('toggle-info');
         const playBtn = document.getElementById('play-btn');
 
+        function attachTTS(){
+            document.querySelectorAll('.tts-group').forEach(g=>g.remove());
+            const items = document.querySelectorAll('[data-tts]');
+            items.forEach(el=>{
+                const text = el.getAttribute('data-tts');
+                const group = document.createElement('div');
+                group.className = 'tts-group';
+
+                const configs = [
+                    {lang:'UK', voice:'Brian', func:()=>playTTSMP3(text,'Brian'), src:'TTSMP3'},
+                    {lang:'US', voice:'Joanna', func:()=>playTTSMP3(text,'Joanna'), src:'TTSMP3'},
+                    {lang:'ES', voice:'Conchita', func:()=>playTTSMP3(text,'Conchita'), src:'TTSMP3'}
+                ];
+
+                configs.forEach(c=>{
+                    const btn = document.createElement('button');
+                    btn.textContent = '🔊 Play';
+                    btn.onclick = c.func;
+                    const tag = document.createElement('span');
+                    tag.className = 'tag';
+                    tag.textContent = `AI Voice • ${c.lang} • ${c.src}`;
+                    group.appendChild(btn);
+                    group.appendChild(tag);
+                });
+
+                el.insertAdjacentElement('afterend', group);
+            });
+        }
+
+        async function playTTSMP3(text, voice){
+            try{
+                const res = await fetch('https://ttsmp3.com/makemp3_new.php',{
+                    method:'POST',
+                    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+                    body:`msg=${encodeURIComponent(text)}&lang=${voice}&source=ttsmp3`
+                });
+                const data = await res.json();
+                if(data.URL){
+                    new Audio(data.URL).play();
+                }else{
+                    playResponsiveVoice(text, voice);
+                }
+            }catch(err){
+                console.error('TTSMP3 Error',err);
+                playResponsiveVoice(text, voice);
+            }
+        }
+
+        function playResponsiveVoice(text, voice){
+            if(typeof responsiveVoice!=='undefined'){
+                responsiveVoice.speak(text, voice);
+            }else{
+                console.warn('ResponsiveVoice not loaded');
+            }
+        }
+
         function showInfo(name) {
-            document.getElementById('county-name').textContent = name + ' County';
+            document.getElementById('county-name').innerHTML = `<span data-tts="${name}">${name} County</span>`;
             document.getElementById('county-phonetic').textContent = phonetics[name] || '';
             const info = countyInfo[name] || {};
             document.getElementById('county-pronunciation').textContent = info.pronunciation ? `Pronunciation: ${info.pronunciation}` : '';
@@ -215,6 +275,7 @@
             const utterance = new SpeechSynthesisUtterance(name + ' County');
             playBtn.onclick = () => speechSynthesis.speak(utterance);
             playBtn.disabled = false;
+            attachTTS();
             expandInfo();
         }
 
@@ -229,6 +290,8 @@
             infoPanel.classList.toggle('expanded');
             toggleBtn.textContent = infoPanel.classList.contains('expanded') ? 'Hide Info' : 'Show Info';
         });
+
+        document.addEventListener('DOMContentLoaded', attachTTS);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add ResponsiveVoice library
- create utility to attach pronunciation buttons for elements with `data-tts`
- use TTSMP3 API with fallback to ResponsiveVoice
- enable pronunciation buttons when showing county info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d77153cf4832786e63287394f1752