### PR TITLE
style: make landing text white

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,6 @@
 - Enhanced landing page design with hero section and call-to-action buttons.
 - Corrected a spelling error in `county_info.json` ("Confederate").
 
+## 2025-08-04 - Ensure hero text is white
+- Added specific CSS rules so the landing page heading and tagline display in white.
+

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
             margin-top: 10px;
             font-size: 1.2em;
             font-weight: 400;
+            color: #fff;
         }
         .container {
             padding: 20px;
@@ -39,6 +40,9 @@
             color: #333;
             font-size: 2em;
             margin-bottom: 0.5em;
+        }
+        .hero h1 {
+            color: #fff;
         }
         p {
             color: #555;


### PR DESCRIPTION
## Summary
- ensure landing page title and tagline render in white for better contrast
- document change in AGENTS log

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910228837c83279e79fdc0562a120e